### PR TITLE
Remove dependency on apache-commons-io.

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -2,6 +2,9 @@
   ZT Exec Changelog
 ********************************************
 
+1.11 (to be released)
+* Removed dependency on Apache's commons-io library
+
 1.10 (1st August 2017)
 * Added support for flushing output after each write
 * Added support for hooks for thread executor creation

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
-<!-- Copyright (C) 2013 ZeroTurnaround <support@zeroturnaround.com> Contains 
-  fragments of code from Apache Commons Exec, rights owned by Apache Software 
-  Foundation (ASF). Licensed under the Apache License, Version 2.0 (the "License"); 
-  you may not use this file except in compliance with the License. You may 
-  obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
-  Unless required by applicable law or agreed to in writing, software distributed 
-  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
-  OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+<!-- Copyright (C) 2013 ZeroTurnaround <support@zeroturnaround.com> Contains
+  fragments of code from Apache Commons Exec, rights owned by Apache Software
+  Foundation (ASF). Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may
+  obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  OR CONDITIONS OF ANY KIND, either express or implied. See the License for
   the specific language governing permissions and limitations under the License. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -43,11 +43,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.5</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.2</version>
@@ -69,6 +64,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/zeroturnaround/exec/ProcessExecutor.java
+++ b/src/main/java/org/zeroturnaround/exec/ProcessExecutor.java
@@ -17,44 +17,25 @@
  */
 package org.zeroturnaround.exec;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import org.apache.commons.io.output.NullOutputStream;
-import org.apache.commons.io.output.TeeOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.zeroturnaround.exec.close.ProcessCloser;
 import org.zeroturnaround.exec.close.StandardProcessCloser;
 import org.zeroturnaround.exec.close.TimeoutProcessCloser;
-import org.zeroturnaround.exec.listener.CompositeProcessListener;
-import org.zeroturnaround.exec.listener.DestroyerListenerAdapter;
-import org.zeroturnaround.exec.listener.ProcessDestroyer;
-import org.zeroturnaround.exec.listener.ProcessListener;
-import org.zeroturnaround.exec.listener.ShutdownHookProcessDestroyer;
+import org.zeroturnaround.exec.listener.*;
 import org.zeroturnaround.exec.stop.DestroyProcessStopper;
 import org.zeroturnaround.exec.stop.NopProcessStopper;
 import org.zeroturnaround.exec.stop.ProcessStopper;
-import org.zeroturnaround.exec.stream.CallerLoggerUtil;
-import org.zeroturnaround.exec.stream.ExecuteStreamHandler;
-import org.zeroturnaround.exec.stream.PumpStreamHandler;
+import org.zeroturnaround.exec.stream.*;
 import org.zeroturnaround.exec.stream.slf4j.Slf4jDebugOutputStream;
 import org.zeroturnaround.exec.stream.slf4j.Slf4jInfoOutputStream;
 import org.zeroturnaround.exec.stream.slf4j.Slf4jStream;
+
+import java.io.*;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.*;
 
 
 

--- a/src/main/java/org/zeroturnaround/exec/stream/NullOutputStream.java
+++ b/src/main/java/org/zeroturnaround/exec/stream/NullOutputStream.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 Ketan Padegaonkar <ketanpadegaonkar@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.zeroturnaround.exec.stream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * An OutputStream which ignores everything written to it.
+ */
+public class NullOutputStream extends OutputStream {
+
+    /**
+     * A singleton.
+     */
+    public static final NullOutputStream NULL_OUTPUT_STREAM = new NullOutputStream();
+
+    public void write(byte[] b, int off, int len) {
+        // discard!
+    }
+
+    public void write(int b) {
+        // discard!
+    }
+
+    public void write(byte[] b) throws IOException {
+        // discard!
+    }
+}

--- a/src/main/java/org/zeroturnaround/exec/stream/TeeOutputStream.java
+++ b/src/main/java/org/zeroturnaround/exec/stream/TeeOutputStream.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2019 Ketan Padegaonkar <ketanpadegaonkar@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.zeroturnaround.exec.stream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Splits an OutputStream into two. Named after the unix 'tee'
+ * command. It allows a stream to be branched off so there
+ * are now two streams.
+ */
+public class TeeOutputStream extends OutputStream {
+    private final OutputStream left;
+    private final OutputStream right;
+
+    public TeeOutputStream(OutputStream left, OutputStream right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    /**
+     * Write a byte array to both output streams.
+     *
+     * @param b   the data.
+     * @param off the start offset in the data.
+     * @param len the number of bytes to write.
+     * @throws IOException on error.
+     */
+    public void write(byte[] b, int off, int len) throws IOException {
+        left.write(b, off, len);
+        right.write(b, off, len);
+    }
+
+
+    /**
+     * Write a byte to both output streams.
+     *
+     * @param b the byte to write.
+     * @throws IOException on error.
+     */
+    public void write(int b) throws IOException {
+        left.write(b);
+        right.write(b);
+    }
+
+
+    /**
+     * Write a byte array to both output streams.
+     *
+     * @param b an array of bytes.
+     * @throws IOException on error.
+     */
+    public void write(byte[] b) throws IOException {
+        left.write(b);
+        right.write(b);
+    }
+
+    /**
+     * Closes both output streams
+     *
+     * @throws IOException on error.
+     */
+    @Override
+    public void close() throws IOException {
+        try {
+            left.close();
+        } finally {
+            right.close();
+        }
+    }
+
+
+    /**
+     * Flush both output streams.
+     *
+     * @throws IOException on error
+     */
+    @Override
+    public void flush() throws IOException {
+        left.flush();
+        right.flush();
+    }
+}

--- a/src/test/java/org/zeroturnaround/exec/stream/TeeOutputStreamTest.java
+++ b/src/test/java/org/zeroturnaround/exec/stream/TeeOutputStreamTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2019 Ketan Padegaonkar <ketanpadegaonkar@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.zeroturnaround.exec.stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.zeroturnaround.exec.test.RememberCloseOutputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class TeeOutputStreamTest {
+
+    public static class ExceptionOnCloseByteArrayOutputStream extends RememberCloseOutputStream {
+
+        public ExceptionOnCloseByteArrayOutputStream(OutputStream out) {
+            super(out);
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            throw new IOException();
+        }
+    }
+
+    @Test
+    public void shouldCopyContentsToBothStreams() throws IOException {
+        ByteArrayOutputStream left = new ByteArrayOutputStream();
+        ByteArrayOutputStream right = new ByteArrayOutputStream();
+        TeeOutputStream teeOutputStream = new TeeOutputStream(left, right);
+
+        teeOutputStream.write(10);
+        teeOutputStream.write(new byte[]{1, 2, 3});
+        teeOutputStream.write(new byte[]{10, 11, 12, 13, 14, 15, 15, 16}, 2, 3);
+
+        Assert.assertArrayEquals(new byte[]{10, 1, 2, 3, 12, 13, 14}, left.toByteArray());
+        Assert.assertArrayEquals(new byte[]{10, 1, 2, 3, 12, 13, 14}, right.toByteArray());
+    }
+
+    @Test
+    public void shouldCloseBothStreamsWhenClosingTee() throws IOException {
+        RememberCloseOutputStream left = new RememberCloseOutputStream(NullOutputStream.NULL_OUTPUT_STREAM);
+        RememberCloseOutputStream right = new RememberCloseOutputStream(NullOutputStream.NULL_OUTPUT_STREAM);
+        TeeOutputStream teeOutputStream = new TeeOutputStream(left, right);
+
+        teeOutputStream.close();
+
+        Assert.assertTrue(left.isClosed());
+        Assert.assertTrue(right.isClosed());
+    }
+
+    @Test
+    public void shouldCloseSecondStreamWhenClosingFirstFails() {
+        ExceptionOnCloseByteArrayOutputStream left = new ExceptionOnCloseByteArrayOutputStream(NullOutputStream.NULL_OUTPUT_STREAM);
+        RememberCloseOutputStream right = new RememberCloseOutputStream(NullOutputStream.NULL_OUTPUT_STREAM);
+        TeeOutputStream teeOutputStream = new TeeOutputStream(left, right);
+        try {
+            teeOutputStream.close();
+            Assert.fail("Was expecting an exception!");
+        } catch (IOException expected) {
+
+        }
+
+        Assert.assertTrue(left.isClosed());
+        Assert.assertTrue(right.isClosed());
+    }
+}


### PR DESCRIPTION
We were using 2 (rather simple?) classes `NullOutputStream`
and `TeeOutputStream` that are simple to implement, so I've re-implemented
them here (with some tests)

Fixes #69